### PR TITLE
Add resume offset param

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Easy way to play videos on your MiSTer through Plex. All you need is SSH access
 - Make sure you do this form a computer that is NOT the one where your Plex server is installed (Otherwise it will create a link to localhost which Mister Plex won't understand) 
 - Pick a video file (ideally sd in 4:3 format) and click on Get Info -> [View XML](https://support.plex.tv/articles/201998867-investigate-media-information-and-formats/)
 - Launch mister plex with `/media/fat/Scripts/mister_plex.sh`
+- To resume from an offset, pass milliseconds as the first argument, for example `/media/fat/Scripts/mister_plex.sh 600`
 - Copy the url of the xml into mister plex script
 
 ## CRT Support

--- a/mister_plex.sh
+++ b/mister_plex.sh
@@ -12,6 +12,9 @@ fi
 
 #### VARIABLES ####
 
+# Optional resume offset in milliseconds. Defaults to 0.
+OFFSET="${1:-0}"
+
 # CRT DEFAULTS
 sv_inimod="yes" #Modify MiSTer.ini to add CRT config mode
 samvideo_output="CRT" 
@@ -76,7 +79,7 @@ misterini_mod
 echo "MiSTer.ini updated successfully with video_mode: $VIDEO_MODE"
 
 # Generate MPlayer command
-TRANSCODE_URL="http://$(echo "$PLEX_URL" | cut -d'/' -f3)/video/:/transcode/universal/start.m3u8?X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&offset=0&path=%2Flibrary%2Fmetadata%2F$METADATA_ID&videoResolution=$VIDEO_RES&maxVideoBitrate=1000&X-Plex-Token=$URL_TOKEN&directStream=0&directPlay=0"
+TRANSCODE_URL="http://$(echo "$PLEX_URL" | cut -d'/' -f3)/video/:/transcode/universal/start.m3u8?X-Plex-Platform=Chrome&copyts=1&mediaIndex=0&offset=$OFFSET&path=%2Flibrary%2Fmetadata%2F$METADATA_ID&videoResolution=$VIDEO_RES&maxVideoBitrate=1000&X-Plex-Token=$URL_TOKEN&directStream=0&directPlay=0"
 
 echo "Generated Transcode URL:"
 echo "$TRANSCODE_URL"


### PR DESCRIPTION
Plex HLS transcode streams are temporary. When you pause too long, Plex or mplayer can decide the stream is stale, close it, and then the script exits

This allows you to resume playback from an offset in milliseconds